### PR TITLE
Change the title to "research project life cycle"

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,5 @@
 ---
-title: Data life cycle
+title: Research project life cycle
 hide_sidebar: true
 ---
 


### PR DESCRIPTION
This PR changes the title of the index page to "Research project life cycle" from "Data life cycle".

Fixes #7 